### PR TITLE
Simplifica template da reunião

### DIFF
--- a/.github/ISSUE_TEMPLATE/reuniao.md
+++ b/.github/ISSUE_TEMPLATE/reuniao.md
@@ -35,4 +35,4 @@ _Adicione os itens que foram discutidos durante a reunião._
 
 ### Ações para serem realizadas
 
-- [ ] Atividade (@responsável)
+- Atividade (@responsável) - #issue

--- a/.github/ISSUE_TEMPLATE/reuniao.md
+++ b/.github/ISSUE_TEMPLATE/reuniao.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ---
 
-_Este template deve ser editado com os itens a serem discutidos durante a reunião. Toda colaboração é bem vinda. Durante a reunião devem ser registradas as participantes e as decisões tomadas, caso hajam informações sensíveis, deve ser criado um arquivo no [Google Drive da organização da Python Brasil 2021](https://drive.google.com/drive/folders/18zvyKpV42k_n_8Sr4a7yo5KxyU_SFgen?usp=sharing) e o link inserido nessa issue. Após o encerramento, o grupo responsável pela reunião deve revisar as informações e fechar a issue em não mais do que uma semana._
+_[Remover antes de abrir o ticket] Este template deve ser editado com os itens a serem discutidos durante a reunião. Toda colaboração é bem vinda. Durante a reunião devem ser registradas as participantes e as decisões tomadas, caso hajam informações sensíveis, deve ser criado um arquivo no [Google Drive da organização da Python Brasil 2021](https://drive.google.com/drive/folders/18zvyKpV42k_n_8Sr4a7yo5KxyU_SFgen?usp=sharing) e o link inserido nessa issue. Após o encerramento, o grupo responsável pela reunião deve revisar as informações e fechar a issue em não mais do que uma semana._
 
 # Reunião <Grupo de trabalho ou tema da reunião>
 
@@ -16,31 +16,23 @@ _Este template deve ser editado com os itens a serem discutidos durante a reuni�
 - Participantes:
   - Nome e Sobrenome (@Github ou E-mail)
 
-## Ata
-
-_Adicione os itens a serem discutidos durante a reunião. Certifique-se de que você estará presente na reunião, pois a ata só pode ser editada por quem a criou_
-
-### Acompanhamento das tarefas
+## Acompanhamento das tarefas
 
 - [ ] Verificar [tarefas bloqueadas](https://github.com/pythonbrasil/pybr2021-org/projects/1?card_filter_query=label%3Abloqueado):
   - Está claro o que precisa ser feito para desbloquear a tarefa?
   - Há parte da tarefa que pode prosseguir de alguma forma?
-- [ ] Verificar [tarefas em andamento](https://github.com/pythonbrasil/pybr2021-org/projects/1)
+- [ ] Verificar [tarefas em andamento](https://github.com/pythonbrasil/pybr2021-org/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+-label%3ABloqueado+-label%3AP%C3%B3s-evento+project%3Apythonbrasil%2Fpybr2021-org%2F1), filtrando as bloqueadas e de pós-evento e ordenando pela últimas que foram atualizadas.
   - A tarefa está associada a uma pessoa responsável?
   - Há algo bloqueando o avanço da tarefa que possa ser discutido?
 - [ ] Verificar [tarefas abertas](https://github.com/pythonbrasil/pybr2021-org/issues?q=is%3Aopen+is%3Aissue+-project%3Apythonbrasil%2Fpybr2021-org%2F1+) não associadas ao projeto no Github.
 
 
-### Itens a serem debatidos
+## Ata
 
-Descrição | Link da Tarefa | Tempo para discussão |
-----------|--------|----------------------|
---| #x | -- |
---| #y | -- | 
---| #z | -- |
+_Adicione os itens que foram discutidos durante a reunião._
 
+- 
 
 ### Ações para serem realizadas
 
-Atividade| Responsável | Link da Tarefa | Observações|
- --| --| --|--|
+- [ ] Atividade (@responsável)


### PR DESCRIPTION
- Movi a seção "Acompanhamento das tarefas" para antes da seção "Ata", já que durante a reunião o acompanhamento das issues abertas é feito antes das discussões da Ata.
- Removi a seção "Itens a serem debatidos", já que estamos usando os comentários da própria issue para guiar o que vai ser discutido.
- Alterei o link de acompanhamento das tarefas em aberto para ordenar pelas que foram atualizadas a mais tempo.
- Troquei a tabela na seção "Ações para serem realizadas" por lista de tarefas. Github tem uma funcionalidade que podemos converter tarefas em uma lista (`- [ ] tarefa`) em uma issue.