### PR TITLE
Insere protocolos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Toda colaboração para o debate é bem vinda. Deixe seu comentário!
 
 ## Informações consolidadas
 
-**Data:** 11 a 17 outubro de 2021
+**Data:** 11 a 17 outubro de 2021 ([issue](https://github.com/pythonbrasil/pybr2021-org/issues/2))
 
 **Local:** Online
 
 **Plataformas:** Streamyard, Discord, Youtube (em contrução)
 
-**Estrutura da programação:**
+**Estrutura da programação:** ([issue](https://github.com/pythonbrasil/pybr2021-org/issues/6))
 | Periodicidade | Atividades|
 | ------------- |-------------|
 |  seg. a sex. | 10h-12h Roda de diálogo<br /> 15h-17h Atividade de patrocinadoras no Discord <br /> 15h-19h05 4 trilhas (pt-br) e 1 trilha internacional (es) <br /> 19h10-20h Palestra instantânea<br /> 20h-21h30 Keynote |
 | sab. a dom.  | 10h-18h Sprints e tutoriais simultâneos |
 
-**Cronograma (previsto) de submissões:**
+**Cronograma (previsto) de submissões:** ([issue](https://github.com/pythonbrasil/pybr2021-org/issues/14))
 - 12 jul.: abertura das submissões
 - 12 ago.: encerramento das submissões
 - 19 ago.: envio para avaliadoras de propostas anonimizadas

--- a/protocolos/patrocinio.md
+++ b/protocolos/patrocinio.md
@@ -1,11 +1,13 @@
-### 👀 Critérios de Avaliação do Patrocinador
+# Protocolo para recepção de patrocínio
+
+## 👀 Critérios de Avaliação do Patrocinador
 
 1. Existem questões em aberto PYBR? E com a APyBR?
 1. A prioridade: ordem de confirmação da assinatura do contrato
 1. Afinidade com o CdC 
 1. Priorizar empresas que estejam que tratem bem a comunidade (e mediante do Comitê de Patrocínio)
 
-### 🕵️‍♀️ Processo de avaliação do Patrocínio
+## 🕵️‍♀️ Processo de avaliação do Patrocínio
 
 - Primeiro contato com patrocinador
 - Agendamento reunião de apresentação
@@ -19,7 +21,7 @@
     - Assinatura do contrato
     - Início de divulgação e outras atividades definidas
 
-### ❓Perguntas - Reuniões
+## ❓Perguntas - Reuniões
 
 Se surgir uma pergunta mais difícil, anota a pergunta e avisa que vai enviar a resposta por email
 

--- a/protocolos/patrocinio.md
+++ b/protocolos/patrocinio.md
@@ -1,0 +1,36 @@
+### 👀 Critérios de Avaliação do Patrocinador
+
+1. Existem questões em aberto PYBR? E com a APyBR?
+1. A prioridade: ordem de confirmação da assinatura do contrato
+1. Afinidade com o CdC 
+1. Priorizar empresas que estejam que tratem bem a comunidade (e mediante do Comitê de Patrocínio)
+
+### 🕵️‍♀️ Processo de avaliação do Patrocínio
+
+- Primeiro contato com patrocinador
+- Agendamento reunião de apresentação
+- Na reunião:
+- Se houver dúvidas
+- Empresa Confirma o interesse no Patrocínio
+- Antes de confirmar o aceite do patrocínio
+- Caso perca a concorrência pela Cota:
+- Caso aprovada:
+    - Envio de contrato para verificação
+    - Assinatura do contrato
+    - Início de divulgação e outras atividades definidas
+
+### ❓Perguntas - Reuniões
+
+Se surgir uma pergunta mais difícil, anota a pergunta e avisa que vai enviar a resposta por email
+
+**TORNAR O EVENTO EXCLUSIVO, SEM SER EXCLUDENTE**
+
+1. Por quê buscamos o patrocínio? O que nos motiva?
+2. Para onde os fundos arrecadados serão destinados?
+3. A empresa conhece a comunidade? Vocês já tem envolvimento? 
+4. A PYBR é capaz de oferecer o que patrocinador procura? A recíproca é verdadeira?
+5. CdC - nossos valores: diversidade, inclusão, comunidade, visibilidade: [mostrar o CdC da PSF](https://www.python.org/psf/conduct/)
+6. PYBR como roteador de informações: Divulgação no canal de notícias, vagas, milhares de pessoas no BR, visibilidade global
+7. Fomento ao evento: sem palestras e sem keynotes
+    1. PYBR: estimula que as empresas apoiem funcionários que queiram palestrar ou realizar atividades técnicas
+    2. A empresa ganha mais visibilidade e passa a ser referência

--- a/protocolos/resposta-incidente-cdc.md
+++ b/protocolos/resposta-incidente-cdc.md
@@ -1,0 +1,106 @@
+# Protocolo da equipe para resposta aos incidentes que infringem o Código de Conduta
+
+Certifique-se de ter um bom entendimento de nosso Código de Conduta, que pode ser encontrado aqui:
+
+- [Código de conduta da Python Brasil](https://python.org.br/cdc/)
+  
+Também tenha um bom entendimento do que se espera de um participante que deseja relatar um incidente. Essas diretrizes podem ser encontradas aqui:
+
+- Procedimento do participante para relatar incidentes do código de conduta[]()
+
+## Ao registrar uma denúncia de incidente:
+1. Seja um ouvinte ativo e empático. Não use palavras de julgamento.
+2. Garanta a segurança do denunciante.
+3. Registre a denúncia e faça perguntas de esclarecimento.
+4. Agradeça ao denunciante por relatar o incidente.
+5. Relate o incidente aos responsáveis ​​pela resposta a incidentes listados abaixo.
+   
+Em caso de conflito de interesses, você pode entrar em contato individualmente:
+
+- Alynne Ferreira - Responsável Geral pela Python Brasil 2021 (e-mail: A DEFINIR)
+
+## Ao coletar informações do denunciante:
+1. Não os convide a retirar o relatório do incidente.
+2. Não peça conselhos sobre como responder imediatamente ao incidente.
+3. Não ofereça a eles informações sobre a resposta de longo prazo ao incidente.
+4. Não prometa nenhuma resposta específica, uma vez que pode ser diferente da resposta oficial decidida pelos responsáveis ​​pela resposta ao incidente.
+   
+Tente obter o máximo de informações ou dados do incidente por escrito pelo denunciante. É necessário ter tudo documentado para nosso próprio respaldo. Se o denunciante não puder, transcreva-o como foi dito a você e peça que de alguma forma ele revise e assine. As informações importantes a serem coletadas incluem o seguinte:
+- Data e hora atuais.
+- Data e hora do incidente.
+- Localização do incidente.
+- Descrição do incidente.
+- Informações de identificação da pessoa infratora: nome, aparência física, roupa, sotaque de voz, informações de identificação (username, nome da apresentação, nome da empresa).
+- Circunstâncias adicionais em torno do incidente.
+- Nome do denunciante ou vítima e informações de contato. Se o denunciante quiser fazer uma denúncia anônima, permita que ele o faça. Se a resposta ao incidente revelar quem relatou o incidente (por exemplo, uma violação em um contexto de uma conversa individual), pergunte ao denunciante se ele tem preocupações de segurança sobre isso.
+- Outras pessoas envolvidas ou testemunhas do incidente e suas informações de contato ou descrição.
+- Não peça sugestões ao denunciante sobre como lidar com o incidente, mas registre as respostas sugeridas, se eles as oferecerem.
+
+Avalie se uma resposta imediata é necessária. Essa resposta inicial é muito importante e definirá a conduta a ser tomada pela Python Brasil. Dependendo da gravidade/detalhes do incidente, siga esta diretriz:
+
+- Depois de registrar a denúncia, avalie se você precisa de um responsável pela resposta do incidente para responder imediatamente ao incidente.
+  
+Resposta às necessidades do denunciante. Você pode:
+
+- Agradeça ao denunciante por fazer a denúncia do incidente.
+- Tranquilize-os de que a denúncia do incidente será revisada pelos responsáveis ​​pela resposta ao incidente.
+- Reúna suas informações de contato para enviar um acompanhamento depois que o incidente for resolvido.
+- Pergunte: "De que outra forma posso lhe ajudar?"
+- Forneça a eles contatos não emergenciais, se necessário o número da polícia ou site oficial da polícia civil para registro de ocorrência. 
+
+Assim que algo for relatado, o responsável geral do evento, o membro da APyB e os responsáveis ​​pela resposta a incidentes devem se reunir. Os principais objetivos desta reunião são:
+
+- Revisar a documentação da denúncia do incidente para determinar o que aconteceu.
+- Consultar a documentação de incidentes anteriores para padrões de comportamento.
+- Discutir as respostas adequadas ao incidente.
+- Designar uma pessoa para fazer essas respostas.
+- Determinar as ações de acompanhamento para qualquer pessoa vítima e/ou o denunciante.
+- Designar uma pessoa para acompanhar as pessoas lesadas.
+  
+Após a reunião e discussão da equipe, um membro da equipe (de preferência o responsável geral da conferência ou membro da APyB, se disponível) pode optar por se comunicar com a pessoa infratora.
+
+## Ao acompanhar uma pessoa infratora:
+- Explique o que aconteceu.
+- Concentre-se no impacto de seu comportamento.
+- Reitere o Código de Conduta e que seu comportamento não foi apropriado.
+- Dê a eles exemplos concretos de como eles podem melhorar seu comportamento.
+- Lembre-os das consequências de seu comportamento ou consequências futuras se o comportamento for repetido.
+  
+As pessoas infratoras geralmente ficam chateadas, na defensiva, agressivas ou negam a denúncia. Permita que eles forneçam detalhes adicionais sobre o incidente. No entanto, lembre-se:
+
+- Não importa se eles não pretendiam machucar ninguém. Seu comportamento ainda impactou negativamente os participantes.
+- Não é seu trabalho tranquilizá-los ou perdoá-los.
+- Não permita que a pessoa infratora peça desculpas à vítima ou à pessoa denunciante. Freqüentemente, um pedido de desculpas centra-se nos sentimentos da pessoa infratora e não na pessoa que foi lesada. Você pode aceitar o pedido de desculpas e se oferecer para repassá-lo (mas você não é obrigado se achar que isso teria um impacto negativo para a vítima ou denunciante).
+
+A seguir, exemplos de possíveis respostas a um relatório de incidente. Esta lista não é inclusiva e a Python Brasil reserva-se o direito de tomar as medidas que julgar necessárias. As possíveis respostas a um incidente incluem:
+
+- Nada, se o comportamento foi determinado como não sendo uma violação do Código de Conduta.
+- Um aviso verbal ou por e-mail.
+- Exigir que a pessoa infratora evite qualquer interação com outra pessoa durante o resto do evento.
+- Exigir que a pessoa infratora não compareça aos eventos.
+- Banir a pessoa dos canais de comunicação do Discord ou chat.
+- Encerrar ou interromper uma interação que viola o Código de Conduta.
+- Não publicar o vídeo ou slides de uma palestra que violou o Código de Conduta.
+- Não permitir que um palestrante que violou o Código de Conduta dê (mais) palestras no evento agora ou no futuro.
+- Terminar imediatamente com as responsabilidades e privilégios voluntários de qualquer evento que uma pessoa detém.
+- Exigir que uma pessoa não se voluntarie para eventos futuros que a organização realize (seja indefinidamente ou por um determinado período de tempo).
+  - Banir uma pessoa de eventos futuros (indefinidamente ou por um determinado período de tempo).
+- Remover uma pessoa da associação a organizações relevantes.
+- Publicar um relato do incidente e pedir a renúncia de uma pessoa de suas responsabilidades (geralmente perseguido por pessoas sem autoridade formal: pode ser chamado se a pessoa for o responsável do evento, ou se recusar a se afastar do conflito de interesses, ou semelhante, normalmente a equipe do evento tem direitos de liderança suficientes sobre seu espaço para que isso não seja tão útil).
+  
+Se uma pessoa infratora quiser apelar da decisão, notifique-a de que ela pode entrar em contato com a APyB contato@python.org.br ou Python Brasil cdc@python.org.br.
+
+**ATENÇÃO:** Lembre-se de que não é uma boa ideia encorajar um pedido de desculpas da pessoa infratora.
+
+É muito importante como lidamos com o incidente publicamente. Nossa política é garantir que todos os que estão cientes do incidente inicial também estejam cientes de que não está de acordo com a política e que uma ação oficial foi tomada - respeitando a privacidade dos participantes individuais. 
+
+Ao falar com pessoas (aqueles que estão cientes do incidente, mas não estiveram envolvidos nele) sobre o incidente, é uma boa ideia manter oculto os detalhes da situação.
+
+Dependendo do incidente, o responsável geral da conferência ou outro responsável pode decidir fazer um ou mais anúncios públicos. Se necessário, isso será feito com um breve anúncio durante o evento e/ou por outros meios de comunicação/canais. Ninguém, a não ser o responsável geral da conferência ou alguém com autoridade delegada por ele, deve fazer qualquer anúncio.
+
+Se alguns participantes ficaram irritados com o incidente, é melhor pedir desculpas a eles. Se houver ressentimentos residuais, sugira que eles escrevam um e-mail para o responsável geral da conferência listado abaixo. Isso será tratado em conformidade.
+
+- Alynne Ferreira - Responsável Geral pela Python Brasil 2021 (e-mail: A DEFINIR)
+
+------------------------
+Este código de conduta foi adaptado a partir do definido pela PyCon US.


### PR DESCRIPTION
Insere os seguintes protocolos:

- Protocolo da equipe para resposta aos incidentes que infringem o Código de Conduta ([arquivo original](https://docs.google.com/document/d/16S_JAE5s0yBH3oux6wFwtmn8oEHGjDHrav60tUfNEoI/edit?usp=sharing))
- Protocolo para recepção de patrocínio (originalmente desenvolvido em arquivo particular de @tiidadavena )